### PR TITLE
remove word boundary as it matches '@' character

### DIFF
--- a/Syntaxes/DiagramEx.sublime-syntax
+++ b/Syntaxes/DiagramEx.sublime-syntax
@@ -63,7 +63,7 @@ contexts:
 
     # control keywords
     - match: |-
-        (?xi) ^ \s* \b (
+        (?xi) ^ \s* (
           @enduml | @startuml | activate | again | also | alt | as | autonumber | bottom | box | break |
           center | create | critical | deactivate | destroy | down | else | end | endif | endwhile | footbox |
           footer | fork | group | header | hide | if | is | left | link | loop | namespace |


### PR DESCRIPTION
Causes @startuml and @enduml to not match because @ is considered a word boundary. I don't see the reason for the \b to exist since the expression is matching beginning of line anyway.

partial fix for https://github.com/evandrocoan/PlantUmlDiagrams/issues/10